### PR TITLE
fix(config): make ctags and workspace opt overwriteable

### DIFF
--- a/lua/gentags/configs.lua
+++ b/lua/gentags/configs.lua
@@ -138,26 +138,7 @@ end
 --- @param opts gentags.Options?
 --- @return gentags.Options
 M.setup = function(opts)
-  local user_ctags = tbl.tbl_get(opts, "ctags") or {}
-  local ctags_opts = vim.deepcopy(Defaults.ctags)
-  for _, o in ipairs(user_ctags) do
-    if str.not_empty(o) then
-      table.insert(ctags_opts, o)
-    end
-  end
-
-  local user_workspace = tbl.tbl_get(opts, "workspace") or {}
-  local workspace_opts = vim.deepcopy(Defaults.workspace)
-  for _, o in ipairs(user_workspace) do
-    if str.not_empty(o) then
-      table.insert(workspace_opts, o)
-    end
-  end
-
-  Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
-  Configs.ctags = ctags_opts
-  Configs.workspace = workspace_opts
-
+    Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   return Configs
 end
 

--- a/lua/gentags/configs.lua
+++ b/lua/gentags/configs.lua
@@ -138,7 +138,7 @@ end
 --- @param opts gentags.Options?
 --- @return gentags.Options
 M.setup = function(opts)
-    Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
+  Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   return Configs
 end
 


### PR DESCRIPTION
**This PR is just a proposal.**
It's not that convenient that we "lock" some default options. For example, under my circumstance, I mainly use this pulgin for a meta-project that only consist of some sub-projects which is managed by VCS separately, and meta-project doesn't have any VCS folder. Without this patch, i can't properly gen one tagfile for the whole project since every  sub-project have a VCS folder.